### PR TITLE
Add branch suggestion feature to CLI

### DIFF
--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -10,6 +10,10 @@ func (m *MockTranslator) translateText(ctx context.Context, text string) (string
 	return m.TranslateTextFunc(ctx, text)
 }
 
+func (m *MockTranslator) suggestBranch(ctx context.Context, text string) (string, error) {
+	return m.TranslateTextFunc(ctx, text)
+}
+
 func (c *CLI) TranslateFile(ctx context.Context, file string) error {
 	return c.translateFile(ctx, file)
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `CLI` structure in the `internal/cli/cli.go` file that allows users to generate a branch name suggestion directly from the provided source code differences. The most important changes include the addition of a new method `suggestBranch` to the `Translator` interface and the `CLI` struct, the introduction of a new flag `branchSuggestion` to the `Run` method of `CLI`, and the implementation of the `suggestBranch` method in the `translator` struct and the `MockTranslator` struct.

New feature implementation:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR39): Added a new method `suggestBranch` to the `Translator` interface and the `CLI` struct. This method takes in a string of source code differences and returns a suggested branch name. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR39) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR235-R263)
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR55-R56): Introduced a new flag `branchSuggestion` to the `Run` method of `CLI`. If this flag is set, the `Run` method will generate a branch name suggestion using the `suggestBranch` method of the `translator` struct and output the suggestion. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR55-R56) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR69-R70) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR92-R113)
* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5R13-R16): Implemented the `suggestBranch` method in the `MockTranslator` struct for testing purposes.