### PR TITLE
Add commit message generation functionality to the CLI

### DIFF
--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -10,7 +10,7 @@ func (m *MockTranslator) translateText(ctx context.Context, text string) (string
 	return m.TranslateTextFunc(ctx, text)
 }
 
-func (m *MockTranslator) suggestBranch(ctx context.Context, text string) (string, error) {
+func (m *MockTranslator) request(ctx context.Context, prompt, text, model string) (string, error) {
 	return m.TranslateTextFunc(ctx, text)
 }
 


### PR DESCRIPTION
This pull request primarily involves changes to the `internal/cli/cli.go` file, focusing on improving the functionality of the command-line interface (CLI). The most significant changes include the modification of the `Translator` interface, the addition of a `commitMessage` flag, and the replacement of the `suggestBranch` method with a more general `request` method.

Here are the key changes:

### Changes to the `Translator` interface:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL39-R39): The `Translator` interface's `suggestBranch` method was replaced with a `request` method. This new method takes four parameters: `ctx`, `prompt`, `input`, and `model`. This change makes the interface more flexible, allowing it to handle different types of requests, not just branch suggestions.

### Addition of a `commitMessage` flag:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR56): A `commitMessage` flag was added to the CLI. This flag allows users to request a commit message suggestion. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR56) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR71)

### Replacement of `suggestBranch` method with `request` method:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL103-R131): The `suggestBranch` method was replaced with the `request` method in the `Run` function. This change allows the CLI to handle different types of requests, such as generating a branch name or a commit message, based on the provided source code differences. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL103-R131) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR292-R320)
* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L13-R13): The `suggestBranch` method was also replaced with the `request` method in the `MockTranslator` struct.

These changes enhance the flexibility of the CLI and extend its functionality, allowing it to handle various types of requests.