### PR TITLE
Add flag to specify model version for text generation

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,6 +55,8 @@ func (c *CLI) Run(args []string) int {
 		branchSuggestion bool
 		commitMessage    bool
 
+		useModel string
+
 		translateFile string
 	)
 
@@ -69,6 +71,7 @@ func (c *CLI) Run(args []string) int {
 
 	flags.BoolVar(&branchSuggestion, "branch", false, "Suggest branch name")
 	flags.BoolVar(&commitMessage, "commit", false, "Suggest commit message")
+	flags.StringVar(&useModel, "model", "gpt-3.5-turbo", "Use model (gpt-3.5-turbo, gpt-4-turbo etc (default: gpt-3.5-turbo))")
 
 	err := flags.Parse(args[1:])
 	if err != nil {
@@ -104,7 +107,7 @@ func (c *CLI) Run(args []string) int {
 
 		prompt := "Generate a branch name directly from the provided source code differences without any additional text or formatting:\n\n"
 
-		suggestion, err := c.translator.request(ctx, prompt, b.String(), "gpt-3.5-turbo")
+		suggestion, err := c.translator.request(ctx, prompt, b.String(), useModel)
 		if err != nil {
 			fmt.Fprintf(c.errStream, "Error: %v\n", err)
 			return ExitCodeFail
@@ -128,7 +131,7 @@ func (c *CLI) Run(args []string) int {
 
 		prompt := "Generate a commit message directly from the provided source code differences without any additional text or formatting:\n\n"
 
-		suggestion, err := c.translator.request(ctx, prompt, b.String(), "gpt-3.5-turbo")
+		suggestion, err := c.translator.request(ctx, prompt, b.String(), useModel)
 		if err != nil {
 			fmt.Fprintf(c.errStream, "Error: %v\n", err)
 			return ExitCodeFail


### PR DESCRIPTION
This pull request includes changes to the `internal/cli/cli.go` file that allow the user to specify the model to be used by the `CLI`'s `Run` function. The changes include the addition of a new `useModel` variable and the modification of the `translator.request` method to use this variable.

Here are the key changes:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR58-R59): Added a new `useModel` variable in the `Run` function.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR74): Added a new flag to specify the model to be used. The default model is "gpt-3.5-turbo".
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL107-R110): Modified the `translator.request` method in the branch name suggestion section of the `Run` function to use the `useModel` variable.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL131-R134): Modified the `translator.request` method in the commit message suggestion section of the `Run` function to use the `useModel` variable.