### PR TITLE
Refactor CLI to handle branch and commit message suggestions

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -94,31 +94,15 @@ func (c *CLI) Run(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
+	var prompt string
+
 	if branchSuggestion {
-		b := strings.Builder{}
-		scanner := bufio.NewScanner(c.inputStream)
-		for scanner.Scan() {
-			text := strings.TrimSpace(scanner.Text())
-			if len(text) == 0 {
-				continue
-			}
-			b.WriteString(text + "\n")
-		}
-
-		prompt := "Generate a branch name directly from the provided source code differences without any additional text or formatting:\n\n"
-
-		suggestion, err := c.translator.request(ctx, prompt, b.String(), useModel)
-		if err != nil {
-			fmt.Fprintf(c.errStream, "Error: %v\n", err)
-			return ExitCodeFail
-		}
-
-		fmt.Fprintf(c.outStream, "%s\n", suggestion)
-
-		return ExitCodeOK
+		prompt = "Generate a branch name directly from the provided source code differences without any additional text or formatting:\n\n"
+	} else if commitMessage {
+		prompt = "Generate a commit message directly from the provided source code differences without any additional text or formatting:\n\n"
 	}
 
-	if commitMessage {
+	if branchSuggestion || commitMessage {
 		b := strings.Builder{}
 		scanner := bufio.NewScanner(c.inputStream)
 		for scanner.Scan() {
@@ -128,8 +112,6 @@ func (c *CLI) Run(args []string) int {
 			}
 			b.WriteString(text + "\n")
 		}
-
-		prompt := "Generate a commit message directly from the provided source code differences without any additional text or formatting:\n\n"
 
 		suggestion, err := c.translator.request(ctx, prompt, b.String(), useModel)
 		if err != nil {


### PR DESCRIPTION
This pull request includes a refactor in the `Run` function in the `internal/cli/cli.go` file. The changes mainly focus on how the `prompt` string is set and the conditions under which the `branchSuggestion` and `commitMessage` blocks are executed.

Here are the key changes:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL97-R105): In the `Run` function, the `branchSuggestion` block has been rearranged. Instead of executing the whole block when `branchSuggestion` is true, now only the `prompt` string is set in this condition. The block for scanning the input stream and making a request to the translator is now executed if either `branchSuggestion` or `commitMessage` is true. This reduces code duplication and makes the function more concise.

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL132-L133): Also in the `Run` function, the `prompt` string for the `commitMessage` block is now set in a separate condition, similar to the `branchSuggestion` block. This makes the function more consistent and easier to read.