### PR TITLE
Include a tip for showing new files in git diff using `git add -N`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@ benri translator and optimizer
 
 ```.gitconfig
 [alias]
-sb = !git diff | bento -branch -model "gpt-4-turbo"
-sc = !git diff --staged | bento -commit -model "gpt-4-turbo"
+sb = !git diff -w | bento -branch -model "gpt-4o"
+sc = !git diff -w --staged | bento -commit -model "gpt-4o"
+```
+
+To show new files in git diff, use the `git add -N` command. This stages the new files without adding content.
+
+```bash
+git add -N .
 ```
 
 ## Name Origin of "bento" 🍱


### PR DESCRIPTION
This pull request includes changes to the `README.md` file in the `benri translator and optimizer` section. The changes update the git aliases `sb` and `sc` to use a different model, `gpt-4o`, and to ignore whitespace changes in the diff. Additionally, a new instruction is added to show new files in git diff using the `git add -N` command.