### PR TITLE
Add `DefaultExceedThreshold`, `Translate` option, refactor logic

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -72,7 +72,7 @@ func TestCLI_translateFile(t *testing.T) {
 	defer tmpFile.Close()
 
 	mockTranslator := &MockTranslator{
-		TranslateTextFunc: func(ctx context.Context, text string) (string, error) {
+		TranslateTextFunc: func(ctx context.Context, prompt, text, model string) (string, error) {
 			return "これはテストです。\nドットなしの別の行", nil
 		},
 	}
@@ -80,7 +80,7 @@ func TestCLI_translateFile(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cl := NewCLI(outStream, errStream, inputStream, mockTranslator)
 
-	err = cl.TranslateFile(ctx, tmpFile.Name())
+	err = cl.TranslateFile(ctx, tmpFile.Name(), "", "test", 1000)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -3,17 +3,13 @@ package cli
 import "context"
 
 type MockTranslator struct {
-	TranslateTextFunc func(ctx context.Context, text string) (string, error)
-}
-
-func (m *MockTranslator) translateText(ctx context.Context, text string) (string, error) {
-	return m.TranslateTextFunc(ctx, text)
+	TranslateTextFunc func(ctx context.Context, prompt, text, model string) (string, error)
 }
 
 func (m *MockTranslator) request(ctx context.Context, prompt, text, model string) (string, error) {
-	return m.TranslateTextFunc(ctx, text)
+	return m.TranslateTextFunc(ctx, prompt, text, model)
 }
 
-func (c *CLI) TranslateFile(ctx context.Context, file string) error {
-	return c.translateFile(ctx, file)
+func (c *CLI) TranslateFile(ctx context.Context, targetFile, prompt, useModel string, limit int) error {
+	return c.translateFile(ctx, targetFile, prompt, useModel, limit)
 }


### PR DESCRIPTION
This pull request includes significant changes to the `internal/cli/cli.go` file, with a focus on enhancing the functionality of the command-line interface (CLI). The changes primarily involve the introduction of new command-line flags, modification of method parameters, and restructuring of the translation process.

Here are the key changes:

**Introduction of new command-line flags:**
* Added a `DefaultExceedThreshold` constant and a `limit` flag to control the number of characters to translate. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR22-R23) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL70-R85)
* Introduced a `translate` flag to trigger the translation process. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR58-R65) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL70-R85)
* Introduced `language` and `prompt` flags to specify the target language and prompt text for translation.
* Replaced `translateFile` flag with `targetFile` flag to specify a target file. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR58-R65) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL70-R85)

**Modification of method parameters:**
* Modified the `translateFile` method to accept additional parameters: `targetFile`, `prompt`, `useModel`, and `limit`. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL153-R165) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL168-R182) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL193-R198)
* Updated the `request` method in the `Translator` interface and its implementation to include `prompt` and `useModel` parameters. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL38) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL222-R233)

**Restructuring of the translation process:**
* Removed the `translateText` method from the `Translator` interface and its implementation. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL38) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL222-R233)
* Updated the `Run` method to use the new flags and call the modified `translateFile` method. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR58-R65) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL70-R85) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL97-R113) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL129-R141)
* Simplified the text formatting process in the `translateFile` method.

**Test updates:**
* Updated the `TestCLI_translateFile` and `MockTranslator` in `internal/cli/cli_test.go` and `internal/cli/export_test.go` to reflect the changes in method parameters. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL75-R83) [[2]](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L6-R14)