### PR TITLE
Add multi and single mode flags, refactor translateFile to multiRequest

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -62,6 +62,9 @@ func (c *CLI) Run(args []string) int {
 		useModel   string
 		targetFile string
 
+		isMultiMode  bool
+		isSingleMode bool
+
 		limit int
 	)
 
@@ -79,6 +82,9 @@ func (c *CLI) Run(args []string) int {
 	flags.BoolVar(&translate, "translate", false, "Translate text")
 
 	flags.IntVar(&limit, "limit", DefaultExceedThreshold, "Limit the number of characters to translate")
+
+	flags.BoolVar(&isMultiMode, "multi", false, "Multi mode")
+	flags.BoolVar(&isSingleMode, "single", false, "Single mode")
 
 	flags.StringVar(&language, "language", "en", "Translate to language (default: en)")
 	flags.StringVar(&prompt, "prompt", "", "Prompt text")
@@ -106,16 +112,22 @@ func (c *CLI) Run(args []string) int {
 	defer stop()
 
 	if branchSuggestion {
+		isSingleMode = true
 		prompt = "Generate a branch name directly from the provided source code differences without any additional text or formatting:\n\n"
 	} else if commitMessage {
+		isSingleMode = true
 		prompt = "Generate a commit message directly from the provided source code differences without any additional text or formatting within 72 characters:\n\n"
 	} else if translate {
+		isMultiMode = true
 		prompt = "Translate the following text to " + language + " without any additional text or formatting:\n\n"
 	}
 
-	singleMode := branchSuggestion || commitMessage
+	if !isSingleMode && !isMultiMode {
+		fmt.Fprintf(c.errStream, "Error: no mode specified\n")
+		return ExitCodeFail
+	}
 
-	if singleMode {
+	if isSingleMode {
 		b := strings.Builder{}
 		scanner := bufio.NewScanner(c.inputStream)
 		for scanner.Scan() {
@@ -137,8 +149,18 @@ func (c *CLI) Run(args []string) int {
 		return ExitCodeOK
 	}
 
-	if targetFile != "" {
-		err := c.translateFile(ctx, targetFile, prompt, useModel, limit)
+	if isMultiMode {
+		if targetFile != "" {
+			f, err := os.Open(targetFile)
+			if err != nil {
+				fmt.Fprintf(c.errStream, "Error: %v\n", err)
+				return ExitCodeFail
+			}
+			defer f.Close()
+			c.inputStream = f
+		}
+
+		err = c.multiRequest(ctx, prompt, useModel, limit)
 		if err != nil {
 			fmt.Fprintf(c.errStream, "Error: %v\n", err)
 			return ExitCodeFail
@@ -161,16 +183,10 @@ func version() string {
 	return info.Main.Version
 }
 
-func (c *CLI) translateFile(ctx context.Context, targetFile, prompt, useModel string, limit int) error {
-	f, err := os.Open(targetFile)
-	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
-	}
-	defer f.Close()
-
+func (c *CLI) multiRequest(ctx context.Context, prompt, useModel string, limit int) error {
 	var b strings.Builder
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(c.inputStream)
 	for scanner.Scan() {
 		text := strings.TrimSpace(scanner.Text())
 		if len(text) == 0 {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -113,12 +113,15 @@ func (c *CLI) Run(args []string) int {
 
 	if branchSuggestion {
 		isSingleMode = true
+		isMultiMode = false
 		prompt = "Generate a branch name directly from the provided source code differences without any additional text or formatting:\n\n"
 	} else if commitMessage {
 		isSingleMode = true
+		isMultiMode = false
 		prompt = "Generate a commit message directly from the provided source code differences without any additional text or formatting within 72 characters:\n\n"
 	} else if translate {
 		isMultiMode = true
+		isSingleMode = false
 		prompt = "Translate the following text to " + language + " without any additional text or formatting:\n\n"
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -77,10 +77,10 @@ func TestCLI_translateFile(t *testing.T) {
 		},
 	}
 
-	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
-	cl := NewCLI(outStream, errStream, inputStream, mockTranslator)
+	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+	cl := NewCLI(outStream, errStream, tmpFile, mockTranslator)
 
-	err = cl.TranslateFile(ctx, tmpFile.Name(), "", "test", 1000)
+	err = cl.MultiRequest(ctx, "", "test", 1000)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -10,6 +10,6 @@ func (m *MockTranslator) request(ctx context.Context, prompt, text, model string
 	return m.TranslateTextFunc(ctx, prompt, text, model)
 }
 
-func (c *CLI) TranslateFile(ctx context.Context, targetFile, prompt, useModel string, limit int) error {
-	return c.translateFile(ctx, targetFile, prompt, useModel, limit)
+func (c *CLI) MultiRequest(ctx context.Context, prompt, useModel string, limit int) error {
+	return c.multiRequest(ctx, prompt, useModel, limit)
 }


### PR DESCRIPTION
This pull request involves modifications to the `internal/cli/cli.go` and related test files. The changes primarily revolve around the introduction of two new modes, `isMultiMode` and `isSingleMode`, in the `Run` function of the `CLI` struct. The changes also include the refactoring of the `translateFile` function into `multiRequest`, and the corresponding adjustments in the test files.

The most important changes are:

New modes:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR65-R67): Added two new boolean variables, `isMultiMode` and `isSingleMode`, in the `Run` function. These modes are set based on the type of operation being performed, such as branch suggestion, commit message, or translation. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR65-R67) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR86-R88)
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR115-R130): Adjusted the logic in the `Run` function to use `isMultiMode` and `isSingleMode` instead of the previous `singleMode` variable. Also, added error handling for cases when no mode is specified.

Function refactoring:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL164-R189): Refactored the `translateFile` function into `multiRequest`. The new function reads from `c.inputStream` instead of a file, allowing it to handle multiple types of input sources. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL164-R189) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR152-R163)

Test adjustments:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL80-R83): Updated the `TestCLI_translateFile` test function to use the new `multiRequest` function instead of the old `translateFile` function.
* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L13-R14): Updated the exported function to use `multiRequest` instead of `translateFile`.