### PR TITLE
Update README.md with usage tips, name origin, and installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ bento is a CLI tool that uses OpenAI's API to assist with everyday tasks. It is 
 - Uses **OpenAI's API** to assist with tasks.
 - Easy-to-use commands: `-branch`, `-commit`, `-translate`.
 - Supports **multi mode** and **single mode**:
-  - `-branch` and `-commit` use `single` mode automatically.
-  - `-translate` uses `multi` mode automatically.
+  - **Single Mode**: Sends one request to the API. Used for `-branch` and `-commit`.
+  - **Multi Mode**: Sends multiple requests to the API. Used for `-translate`.
 
-## Multi Mode vs Single Mode
+## Name Origin of "bento" 🍱
 
-* **Single Mode**: Sends one request to the API. Used for `-branch` and `-commit`.
-* **Multi Mode**: Sends multiple requests to the API. Used for `-translate`.
+The name "bento" stands for **Benri Translator and Optimizer**. The word "benri" is Japanese for "convenient," which reflects the tool's purpose to provide handy solutions and optimizations.
+
+In Japanese, "bento" refers to a lunch box that contains a variety of different dishes. This analogy is perfect for our tool because it combines multiple functionalities into one compact tool, much like a bento box 🍱 that offers a variety of foods in one compact container. Thus, our "bento" tool is designed to be a versatile and efficient assistant in your workflow, packing numerous features in an organized manner.
 
 ## Usage
 
@@ -50,6 +51,23 @@ Usage of bento:
 
 ## Installation
 
+
+It is recommended that you use the binaries available on [GitHub Releases](https://github.com/catatsuy/bento/releases). It is advisable to download and use the latest version.
+
+If you have a Go language development environment set up, you can also compile and install the 'bento' tools on your own.
+
+```bash
+go install github.com/catatsuy/bento@latest
+```
+
+To build and modify the 'bento' tools for development purposes, you can use the `make` command.
+
+```bash
+make
+```
+
+If you use the `make` command to build and install the 'bento' tool, the output of the `bento -version` command will be the git commit ID of the current version.
+
 ## Additional Information
 
 - **API Token**: The API token is passed via the environment variable `OPENAI_API_KEY`.
@@ -57,8 +75,6 @@ Usage of bento:
 - **Default Model**: The default model is `gpt-3.5-turbo`, but you can change it with the `-model` option.
 - **Translation**: The `-translate` command translates to English by default; use `-language` to specify the target language.
 - **File Handling**: To work with files, provide the filename with `-file` or use standard input.
-- **Branch Prompt**: The prompt for `-branch` is `Generate a branch name directly from the provided source code differences without any additional text or formatting:`.
-  - If providing a custom prompt, it is recommended to add `"without any additional text or formatting"` at the end.
 
 ## Using `-branch` and `-commit`
 
@@ -83,8 +99,6 @@ To show new files in git diff, use the `git add -N` command. This stages the new
 git add -N .
 ```
 
-## Name Origin of "bento" 🍱
+## Tips
 
-The name "bento" stands for **Benri Translator and Optimizer**. The word "benri" is Japanese for "convenient," which reflects the tool's purpose to provide handy solutions and optimizations.
-
-In Japanese, "bento" refers to a lunch box that contains a variety of different dishes. This analogy is perfect for our tool because it combines multiple functionalities into one compact tool, much like a bento box 🍱 that offers a variety of foods in one compact container. Thus, our "bento" tool is designed to be a versatile and efficient assistant in your workflow, packing numerous features in an organized manner.
+- **Prompt Tips**: When using `-branch`, the default prompt is: `Generate a branch name directly from the provided source code differences without any additional text or formatting:`. If you provide a custom prompt, it is recommended to add `"without any additional text or formatting"` at the end for better results.


### PR DESCRIPTION
This pull request primarily updates the `README.md` file for the `bento` CLI tool. The changes aim to improve the clarity of the tool's usage and provide additional context about the tool's name origin. The key changes include a reorganization of the information about the tool's modes, an addition of a new section about the tool's installation, and a relocation of the tip for using the `-branch` command.

Reorganization of tool's modes:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R19): The explanation of the tool's modes (`single` and `multi`) has been moved from a separate section into the list of features. This change makes the modes' usage clearer in the context of the `-branch`, `-commit`, and `-translate` commands.

Addition of installation section:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-L61): A new section has been added to provide instructions on how to install the `bento` tool. This includes links to the binaries on GitHub Releases, instructions for installing with Go, and details on building the tool with the `make` command.

Relocation of `-branch` command tip:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R104): The tip for using the `-branch` command has been moved from the "Additional Information" section to a new "Tips" section. This change makes the tip more prominent and easier to find.