### PR TITLE
Update ldflags Version path in Makefile from cli to internal/cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ go.mod go.sum:
 	go mod tidy
 
 bin/bento: main.go go.mod $(wildcard internal/**/*.go)
-	go build -ldflags "-X github.com/catatsuy/bento/cli.Version=`git rev-list HEAD -n1`" -o bin/bento main.go
+	go build -ldflags "-X github.com/catatsuy/bento/internal/cli.Version=`git rev-list HEAD -n1`" -o bin/bento main.go
 
 .PHONY: test
 test:


### PR DESCRIPTION
This pull request includes a change to the `Makefile` that adjusts the build command for the `bento` binary. Specifically, the `-ldflags` option of the `go build` command has been updated to reference the `Version` variable in the `github.com/catatsuy/bento/internal/cli` package instead of the `github.com/catatsuy/bento/cli` package. This change suggests a restructuring of the project's internal packages.