### PR TITLE
Update Go version to 1.22.4 and GoReleaser action to v6 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.22.4
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
This pull request includes updates to the `release.yml` file in the `.github/workflows` directory. The changes involve updating the Go version and the GoReleaser action version used in the workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R17): The Go version used in the setup has been specified to `1.22.4` from `1.22.x`, providing more control over the Go version used. The GoReleaser action version has also been updated to `v6` from `v5`, which could include new features or bug fixes from the GoReleaser team.