### PR TITLE
Add regexManagers for Go version in renovate.json for security workflow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        ".github/workflows/security.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
This pull request includes changes to the `renovate.json` configuration file to enhance the Renovate bot's functionality. The most significant changes involve the removal of the `$schema` reference, the addition of a `regexManagers` section to manage the Go version in the `.github/workflows/security.yml` file, and the introduction of `postUpdateOptions` to tidy up and update import paths after updates.

Detailed changes:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2-R19): Removed the `$schema` reference. This change doesn't affect the functionality of the Renovate bot.
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2-R19): Added a `regexManagers` section. This new section allows the Renovate bot to manage the Go version in the `.github/workflows/security.yml` file. The bot will use a regular expression to match the current Go version and update it when necessary.
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2-R19): Introduced `postUpdateOptions` with `gomodTidy` and `gomodUpdateImportPaths`. These options instruct the Renovate bot to tidy up the Go modules file and update the import paths after any updates, ensuring the project's dependencies remain clean and up-to-date.