### PR TITLE
Clarify bento setup as Git alias in git config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you use the `make` command to build and install the 'bento' tool, the output 
 
 ### Example
 
-Here is an example of setting up bento as a Git alias. This allows you to generate branch names and commit messages from Git diffs automatically.
+Here is an example of setting up bento as a Git alias on `~/.gitconfig`. This allows you to generate branch names and commit messages from Git diffs automatically.
 
 ```.gitconfig
 [alias]


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change clarifies the setup instructions for `bento` as a Git alias by specifying that the alias should be set up in the `~/.gitconfig` file.