### PR TITLE
Add terminal check in CLI constructor, update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/catatsuy/bento
 go 1.21.4
 
 require github.com/google/go-cmp v0.6.0
+
+require (
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/term v0.21.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.21.0 h1:WVXCp+/EBEHOj53Rvu+7KiT/iElMrO8ACK16SMZ3jaA=
+golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRun_versionFlg(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
-	cl := NewCLI(outStream, errStream, inputStream, nil)
+	cl := NewCLI(outStream, errStream, inputStream, nil, false)
 
 	args := strings.Split("bento -version", " ")
 	status := cl.Run(args)
@@ -30,7 +30,7 @@ func TestRun_versionFlg(t *testing.T) {
 
 func TestRun_helpSuccess(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
-	cl := NewCLI(outStream, errStream, inputStream, nil)
+	cl := NewCLI(outStream, errStream, inputStream, nil, false)
 
 	args := strings.Split("bento -help", " ")
 	status := cl.Run(args)
@@ -47,7 +47,7 @@ func TestRun_helpSuccess(t *testing.T) {
 
 func TestRun_hSuccess(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
-	cl := NewCLI(outStream, errStream, inputStream, nil)
+	cl := NewCLI(outStream, errStream, inputStream, nil, false)
 
 	args := strings.Split("bento -h", " ")
 	status := cl.Run(args)
@@ -78,7 +78,7 @@ func TestCLI_translateFile(t *testing.T) {
 	}
 
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
-	cl := NewCLI(outStream, errStream, tmpFile, mockTranslator)
+	cl := NewCLI(outStream, errStream, tmpFile, mockTranslator, false)
 
 	err = cl.MultiRequest(ctx, "", "test", 1000)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ import (
 	"os"
 
 	"github.com/catatsuy/bento/internal/cli"
+	"golang.org/x/term"
 )
 
 func main() {
 	tr, _ := cli.NewTranslator()
-	cl := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin, tr)
+	cl := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin, tr, term.IsTerminal(int(os.Stdin.Fd())))
 	os.Exit(cl.Run(os.Args))
 }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the functionality of the `CLI` struct in the `internal/cli/cli.go` file. The changes include the addition of a new field `isStdinTerminal` to the `CLI` struct, modifications to the `NewCLI` function to accommodate the new field, and updates to the `Run` method to handle different conditions based on the `isStdinTerminal` value. Additionally, the `go.mod` file has been updated to include new dependencies, and corresponding changes have been made in the test files and `main.go`.

Here are the key changes:

Changes to `CLI` struct:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR34-R35): A new boolean field `isStdinTerminal` has been added to the `CLI` struct. This field is used to check if the standard input is a terminal.

Updates to `NewCLI` function:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL43-R46): The `NewCLI` function has been modified to include `isStdinTerminal` as a new parameter. This change is reflected wherever `NewCLI` is invoked throughout the codebase. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL43-R46) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL16-R16) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL33-R33) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL50-R50) [[5]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL81-R81) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R7-R12)

Modifications to `Run` method:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR131-R140): The `Run` method has been updated to handle different conditions based on the `isStdinTerminal` value. If `isStdinTerminal` is true and no target file is provided, or if `isStdinTerminal` is false and a target file is provided, an error message is displayed and the program exits.

Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-R10): New dependencies `golang.org/x/sys` and `golang.org/x/term` have been added to the `go.mod` file. The `term` package is used in `main.go` to check if the standard input is a terminal. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-R10) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R7-R12)