### PR TITLE
Reorder README sections for `-branch` and `-commit` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@ If you use the `make` command to build and install the 'bento' tool, the output 
 - **Translation**: The `-translate` command translates to English by default; use `-language` to specify the target language.
 - **File Handling**: To work with files, provide the filename with `-file` or use standard input.
 
-## Using `-branch` and `-commit`
-
-- **`-branch`**: Use this when you haven't created a branch yet. It suggests a branch name based on the current Git diff.
-  - Large new files can be problematic for the API to handle. By default, Git diff excludes new files, which is convenient. If necessary, add new files with `git add -N`.
-- **`-commit`**: Use this when you are ready to commit. It suggests a commit message based on the staged files.
-  - If new files cause large diffs, generate the commit message before staging them to avoid exceeding API limits.
-
 ## Usage Examples
 
 ```
@@ -83,6 +76,11 @@ Usage of bento:
 ```
 
 ### Using `-branch` and `-commit`
+
+- **`-branch`**: Use this when you haven't created a branch yet. It suggests a branch name based on the current Git diff.
+  - Large new files can be problematic for the API to handle. By default, Git diff excludes new files, which is convenient. If necessary, add new files with `git add -N`.
+- **`-commit`**: Use this when you are ready to commit. It suggests a commit message based on the staged files.
+  - If new files cause large diffs, generate the commit message before staging them to avoid exceeding API limits.
 
 Here is an example of setting up bento as a Git alias on `~/.gitconfig`. This allows you to generate branch names and commit messages from Git diffs automatically.
 


### PR DESCRIPTION
This pull request includes changes to the `README.md` file that restructure the information about the usage of `-branch` and `-commit` options in the 'bento' tool. The details about these options have been moved from an earlier section to the "Usage of bento:" section for better context and understanding.

Here are the key changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-L53): The details about using `-branch` and `-commit` options, which were previously under the "Using `-branch` and `-commit`" section, have been removed.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R84): The removed details about `-branch` and `-commit` options have been added to the "Usage of bento:" section to provide better context about their usage.