### PR TITLE
Fix project_name from purl to bento in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,13 +1,13 @@
-project_name: purl
+project_name: bento
 before:
   hooks:
     - go mod tidy
 builds:
   - main: ./main.go
-    binary: purl
+    binary: bento
     ldflags:
       - -s -w
-      - -X github.com/catatsuy/purl/internal/cli.Version=v{{.Version}}
+      - -X github.com/catatsuy/bento/internal/cli.Version=v{{.Version}}
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This pull request includes changes to the `.goreleaser.yml` file to rename the project and binary from `purl` to `bento`. The changes also update the versioning reference in the `ldflags` section to reflect this new name.

Here's the key change:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L1-R10): The `project_name` and `binary` fields have been updated from `purl` to `bento`. The versioning reference in the `ldflags` section has also been updated to `github.com/catatsuy/bento/internal/cli.Version=v{{.Version}}` from `github.com/catatsuy/purl/internal/cli.Version=v{{.Version}}`.