### PR TITLE
Update Go version and adjust module dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/catatsuy/bento
 
-go 1.21.4
-
-require github.com/google/go-cmp v0.6.0
+go 1.22.4
 
 require (
-	golang.org/x/sys v0.21.0 // indirect
-	golang.org/x/term v0.21.0 // indirect
+	github.com/google/go-cmp v0.6.0
+	golang.org/x/term v0.21.0
 )
+
+require golang.org/x/sys v0.21.0 // indirect


### PR DESCRIPTION
This pull request includes changes to the `go.mod` file. These changes primarily involve updates to the Go version and the arrangement of dependencies.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R10): The Go version has been updated from 1.21.4 to 1.22.4. The arrangement of dependencies has also been modified, but the versions remain the same.