### PR TITLE
fix appVersion

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -99,12 +99,12 @@ func (c *CLI) Run(args []string) int {
 	}
 
 	if version {
-		fmt.Fprintf(c.errStream, "bento version %s; %s\n", Version, runtime.Version())
+		fmt.Fprintf(c.errStream, "bento version %s; %s\n", c.appVersion, runtime.Version())
 		return ExitCodeOK
 	}
 
 	if help {
-		fmt.Fprintf(c.errStream, "bento version %s; %s\n", Version, runtime.Version())
+		fmt.Fprintf(c.errStream, "bento version %s; %s\n", c.appVersion, runtime.Version())
 		fmt.Fprintf(c.errStream, "Usage of bento:\n")
 		flags.PrintDefaults()
 		return ExitCodeOK


### PR DESCRIPTION
This pull request includes a change to the `Run` method in the `CLI` struct within the `internal/cli/cli.go` file. The change replaces the use of the global `Version` variable with the `appVersion` field of the `CLI` struct when printing the version of the application. This change is likely to provide more flexibility and control over the versioning of the application.