### PR TITLE
Clarify model usage string in CLI help text

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -90,7 +90,7 @@ func (c *CLI) Run(args []string) int {
 
 	flags.StringVar(&language, "language", "", "Translate to language (default: en)")
 	flags.StringVar(&prompt, "prompt", "", "Prompt text")
-	flags.StringVar(&useModel, "model", "gpt-3.5-turbo", "Use model (gpt-3.5-turbo, gpt-4-turbo and gpt-4o etc (default: gpt-3.5-turbo))")
+	flags.StringVar(&useModel, "model", "gpt-3.5-turbo", "Use models such as gpt-3.5-turbo, gpt-4-turbo, and gpt-4o")
 
 	err := flags.Parse(args[1:])
 	if err != nil {


### PR DESCRIPTION
This pull request includes a minor change to the `Run` function in the `internal/cli/cli.go` file. The change modifies the description of the `model` flag to clarify its usage. Instead of indicating a default value, the new description provides examples of potential models that can be used, such as `gpt-3.5-turbo`, `gpt-4-turbo`, and `gpt-4o`.