### PR TITLE
Add API key parameter to NewClient and NewTranslator functions

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -253,8 +253,8 @@ type translator struct {
 	client *openai.Client
 }
 
-func NewTranslator() (*translator, error) {
-	client, err := openai.NewClient(openai.OpenAIAPIURL)
+func NewTranslator(apiKey string) (*translator, error) {
+	client, err := openai.NewClient(openai.OpenAIAPIURL, apiKey)
 	if err != nil {
 		return nil, fmt.Errorf("NewClient: %w", err)
 	}

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 )
 
@@ -19,6 +18,7 @@ var (
 type Client struct {
 	URL        *url.URL
 	HTTPClient *http.Client
+	APIKey     string
 }
 
 type Payload struct {
@@ -52,9 +52,13 @@ type Usage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-func NewClient(urlStr string) (*Client, error) {
+func NewClient(urlStr, apiKey string) (*Client, error) {
 	if len(urlStr) == 0 {
 		return nil, fmt.Errorf("client: missing url")
+	}
+
+	if len(apiKey) == 0 {
+		return nil, fmt.Errorf("client: missing api key")
 	}
 
 	parsedURL, err := url.ParseRequestURI(urlStr)
@@ -65,6 +69,7 @@ func NewClient(urlStr string) (*Client, error) {
 	client := &Client{
 		URL:        parsedURL,
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		APIKey:     apiKey,
 	}
 
 	return client, nil
@@ -95,8 +100,7 @@ func (c *Client) Chat(ctx context.Context, param *Payload) (*Response, error) {
 		return nil, err
 	}
 
-	apiKey := os.Getenv("OPENAI_API_KEY")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.HTTPClient.Do(req)

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -29,11 +29,19 @@ func TestPostText_Success(t *testing.T) {
 		},
 	}
 
+	token := "token"
+
 	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		contentType := r.Header.Get("Content-Type")
 		expectedType := "application/json"
 		if contentType != expectedType {
 			t.Fatalf("Content-Type expected %s, but %s", expectedType, contentType)
+		}
+
+		authorization := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + token
+		if authorization != expectedAuth {
+			t.Fatalf("Authorization expected %s, but %s", expectedAuth, authorization)
 		}
 
 		bodyBytes, err := io.ReadAll(r.Body)
@@ -55,7 +63,7 @@ func TestPostText_Success(t *testing.T) {
 		http.ServeFile(w, r, "testdata/chat_ok.json")
 	})
 
-	c, err := NewClient(testAPIServer.URL)
+	c, err := NewClient(testAPIServer.URL, token)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +120,7 @@ func TestPostText_Fail(t *testing.T) {
 		http.ServeFile(w, r, "testdata/chat_fail.json")
 	})
 
-	c, err := NewClient(testAPIServer.URL)
+	c, err := NewClient(testAPIServer.URL, "token")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,16 @@ import (
 )
 
 func main() {
-	tr, _ := cli.NewTranslator()
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		os.Stderr.WriteString("you need to set OPENAI_API_KEY\n")
+		os.Exit(1)
+	}
+	tr, err := cli.NewTranslator(apiKey)
+	if err != nil {
+		os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
+	}
 	cl := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin, tr, term.IsTerminal(int(os.Stdin.Fd())))
 	os.Exit(cl.Run(os.Args))
 }


### PR DESCRIPTION
This pull request primarily focuses on changes to the OpenAI client within the `internal/cli/cli.go` and `internal/openai/client.go` files. The main change is the removal of the dependency on the `os` package to fetch the OpenAI API key from the environment variables. Instead, the API key is now passed as an argument when creating a new client. This change is reflected across the codebase, including in the tests and the main program.

API Key Handling:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL256-R257): The `NewTranslator` function now accepts an API key as an argument instead of fetching it from the environment variables.
* [`internal/openai/client.go`](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbL11): The `Client` struct now includes an `APIKey` field. The `NewClient` function accepts the API key as an argument and validates it. The `Chat` function uses the API key from the `Client` struct instead of the environment variables. [[1]](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbL11) [[2]](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbR21) [[3]](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbL55-R63) [[4]](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbR72) [[5]](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbL98-R103)
* [`internal/openai/client_test.go`](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764R32-R46): The tests for the client have been updated to pass an API key when creating a new client and to validate the `Authorization` header. [[1]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764R32-R46) [[2]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L58-R66) [[3]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L115-R123)
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L11-R20): The main program fetches the API key from the environment variables and passes it to the `NewTranslator` function. It also includes error handling for the case where the API key is not set.