### PR TITLE
Update renovate.json to include Go version match for release workflow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
       "matchStrings": [
         "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "fileMatch": [
+        ".github/workflows/release.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file. The change adds a new configuration for matching the Golang version in the `.github/workflows/release.yml` file. This will allow Renovate to automatically update the Golang version in this file when a new version is released.