### PR TITLE
Change default model from gpt-3.5-turbo to gpt-4o-mini in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you use the `make` command to build and install the 'bento' tool, the output 
 
 - **API Token**: The API token is passed via the environment variable `OPENAI_API_KEY`.
 - **Customization**: To customize, use `-multi` or `-single` and provide a custom prompt with `-prompt`.
-- **Default Model**: The default model is `gpt-3.5-turbo`, but you can change it with the `-model` option.
+- **Default Model**: The default model is `gpt-4o-mini`, but you can change it with the `-model` option.
 - **Translation**: The `-translate` command translates to English by default; use `-language` to specify the target language.
 - **File Handling**: To work with files, provide the filename with `-file` or use standard input.
 
@@ -62,7 +62,7 @@ Usage of bento:
   -limit int
         Limit the number of characters to translate (default 4000)
   -model string
-        Use models such as gpt-3.5-turbo, gpt-4-turbo, and gpt-4o (default "gpt-3.5-turbo")
+        Use models such as gpt-4o-mini, gpt-4-turbo, and gpt-4o (default "gpt-4o-mini")
   -multi
         Multi mode
   -prompt string
@@ -86,8 +86,8 @@ Here is an example of setting up bento as a Git alias on `~/.gitconfig`. This al
 
 ```.gitconfig
 [alias]
-sb = !git diff -w | bento -branch -model "gpt-4o"
-sc = !git diff -w --staged | bento -commit -model "gpt-4o"
+sb = !git diff -w | bento -branch
+sc = !git diff -w --staged | bento -commit
 ```
 
 To show new files in git diff, use the `git add -N` command. This stages the new files without adding content.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -90,7 +90,7 @@ func (c *CLI) Run(args []string) int {
 
 	flags.StringVar(&language, "language", "", "Translate to language (default: en)")
 	flags.StringVar(&prompt, "prompt", "", "Prompt text")
-	flags.StringVar(&useModel, "model", "gpt-3.5-turbo", "Use models such as gpt-3.5-turbo, gpt-4-turbo, and gpt-4o")
+	flags.StringVar(&useModel, "model", "gpt-4o-mini", "Use models such as gpt-4o-mini, gpt-4-turbo, and gpt-4o")
 
 	err := flags.Parse(args[1:])
 	if err != nil {


### PR DESCRIPTION
This pull request primarily updates the default model used in the 'bento' tool from `gpt-3.5-turbo` to `gpt-4o-mini`. The changes are reflected in the tool's usage instructions in the `README.md` file and in the command-line interface setup in the `internal/cli/cli.go` file. Additionally, the Git alias setup in the `README.md` file has been simplified.

Changes to the 'bento' tool:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43): Updated the default model in the 'bento' tool usage instructions from `gpt-3.5-turbo` to `gpt-4o-mini`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R65)
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL93-R93): Changed the default model in the command-line interface setup from `gpt-3.5-turbo` to `gpt-4o-mini`.

Changes to the Git alias setup:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R90): Simplified the Git alias setup by removing the `-model` option from the `sb` and `sc` aliases.