### PR TITLE
use renovate for go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,24 +5,23 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.0"
 
-    - name: Build
-      run: make
+      - name: Build
+        run: make
 
-    - name: Test
-      run: make test
+      - name: Test
+        run: make test

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,16 @@
   "regexManagers": [
     {
       "fileMatch": [
+        ".github/workflows/go.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "fileMatch": [
         ".github/workflows/security.yml"
       ],
       "datasourceTemplate": "golang-version",


### PR DESCRIPTION
This pull request includes changes to the CI configuration and dependency management for the Go project. The most important changes involve updating the Go version in the workflow and adding a regex manager in the `renovate.json` file.

CI Configuration Updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL22-R21): Changed the Go version specification from `1.22` to `1.22.0` to ensure precise versioning.

Dependency Management Enhancements:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R6-R15): Added a regex manager for the `.github/workflows/go.yml` file to track and manage the Go version specified in the workflow.