### PR TITLE
Update Go version format in GitHub Actions workflow to 1.22.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.0"
+          go-version: 1.22.0
 
       - name: Build
         run: make


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/go.yml` file. The change involves updating the `go-version` format in the `Set up Go` step.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL21-R21): Updated the `go-version` format from a string to a number in the `Set up Go` step.