### PR TITLE
Refactor CLI to include system prompt in request methods and tests

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -72,7 +72,7 @@ func TestCLI_translateFile(t *testing.T) {
 	defer tmpFile.Close()
 
 	mockTranslator := &MockTranslator{
-		TranslateTextFunc: func(ctx context.Context, prompt, text, model string) (string, error) {
+		TranslateTextFunc: func(ctx context.Context, systemPrompt, prompt, text, model string) (string, error) {
 			return "これはテストです。\nドットなしの別の行", nil
 		},
 	}
@@ -80,7 +80,7 @@ func TestCLI_translateFile(t *testing.T) {
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
 	cl := NewCLI(outStream, errStream, tmpFile, mockTranslator, false)
 
-	err = cl.MultiRequest(ctx, "", "test", 1000)
+	err = cl.MultiRequest(ctx, "", "", "test", 1000)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -3,13 +3,13 @@ package cli
 import "context"
 
 type MockTranslator struct {
-	TranslateTextFunc func(ctx context.Context, prompt, text, model string) (string, error)
+	TranslateTextFunc func(ctx context.Context, systemPrompt, prompt, text, model string) (string, error)
 }
 
-func (m *MockTranslator) request(ctx context.Context, prompt, text, model string) (string, error) {
-	return m.TranslateTextFunc(ctx, prompt, text, model)
+func (m *MockTranslator) request(ctx context.Context, systemPrompt, prompt, text, model string) (string, error) {
+	return m.TranslateTextFunc(ctx, systemPrompt, prompt, text, model)
 }
 
-func (c *CLI) MultiRequest(ctx context.Context, prompt, useModel string, limit int) error {
-	return c.multiRequest(ctx, prompt, useModel, limit)
+func (c *CLI) MultiRequest(ctx context.Context, systemPrompt, prompt, useModel string, limit int) error {
+	return c.multiRequest(ctx, systemPrompt, prompt, useModel, limit)
 }


### PR DESCRIPTION
This pull request introduces a new `systemPrompt` parameter to the CLI tool, which allows for more detailed and context-specific translations. The changes span several functions and include updates to both the implementation and the tests.

### Implementation Changes:

* `internal/cli/cli.go`: 
  * Added `systemPrompt` parameter to the `Translator` interface's `request` method.
  * Updated the `Run` method to handle the new `systemPrompt` parameter. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR64) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR94) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL175-R177) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL187-R189)
  * Modified the `multiRequest` method to include `systemPrompt`. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL210-R212) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL225-R227) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL237-R239)
  * Adjusted the `request` method in the `translator` struct to handle the `systemPrompt` and construct the payload accordingly. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL266-R290) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR299)

### Test Updates:

* `internal/cli/cli_test.go`:
  * Updated mock translator and tests to accommodate the new `systemPrompt` parameter.

* `internal/cli/export_test.go`:
  * Modified the `MockTranslator` and related functions to include `systemPrompt`.