### PR TITLE
Rename variable 'by' to 'content' for improved clarity in cli.go

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -180,13 +180,13 @@ If you find a problem, briefly explain the issue and provide a specific suggesti
 	}
 
 	if isSingleMode {
-		by, err := io.ReadAll(c.inputStream)
+		content, err := io.ReadAll(c.inputStream)
 		if err != nil {
 			fmt.Fprintf(c.errStream, "Error: %v\n", err)
 			return ExitCodeFail
 		}
 
-		suggestion, err := c.translator.request(ctx, systemPrompt, prompt, string(by), useModel)
+		suggestion, err := c.translator.request(ctx, systemPrompt, prompt, string(content), useModel)
 		if err != nil {
 			fmt.Fprintf(c.errStream, "Error: %v\n", err)
 			return ExitCodeFail


### PR DESCRIPTION
This pull request includes a small change to the `internal/cli/cli.go` file. The change improves code readability by renaming a variable.

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL183-R189): Renamed the variable `by` to `content` for better clarity.