### PR TITLE
Add error handling for insufficient CLI arguments in Run method

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,8 +46,10 @@ func NewCLI(outStream, errStream io.Writer, inputStream io.Reader, tr Translator
 	return &CLI{appVersion: version(), outStream: outStream, errStream: errStream, inputStream: inputStream, translator: tr, isStdinTerminal: isStdinTerminal}
 }
 
+// Run parses the CLI arguments and executes the appropriate functionality based on the provided flags.
 func (c *CLI) Run(args []string) int {
 	if len(args) <= 1 {
+		fmt.Fprintf(c.errStream, "Error: Insufficient arguments provided\n")
 		return ExitCodeFail
 	}
 


### PR DESCRIPTION
This pull request includes a small enhancement to the `Run` method in the `CLI` class within the `internal/cli/cli.go` file. The change adds an error message output for cases where insufficient arguments are provided.

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR49-R52): Added an error message output to the `Run` method to handle cases with insufficient arguments.