### PR TITLE
Update CLI help text and default to single mode if no mode is specified

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -91,7 +91,7 @@ func (c *CLI) Run(args []string) int {
 	flags.IntVar(&limit, "limit", DefaultExceedThreshold, "Limit the number of characters to translate")
 
 	flags.BoolVar(&isMultiMode, "multi", false, "Multi mode")
-	flags.BoolVar(&isSingleMode, "single", false, "Single mode")
+	flags.BoolVar(&isSingleMode, "single", false, "Single mode (default)")
 
 	flags.StringVar(&language, "language", "", "Translate to language (default: en)")
 	flags.StringVar(&prompt, "prompt", "", "Prompt text")
@@ -120,8 +120,13 @@ func (c *CLI) Run(args []string) int {
 	defer stop()
 
 	if isSingleMode && isMultiMode {
-		fmt.Fprintf(c.errStream, "Error: The '-single' and '-multi' options cannot be used together. Please specify only one of these options.\n")
+		fmt.Fprintf(c.errStream, "Error: Both 'multi' and 'single' modes cannot be specified simultaneously.\n")
 		return ExitCodeFail
+	}
+
+	if !isMultiMode && !isSingleMode {
+		// Default to single mode if no mode is specified
+		isSingleMode = true
 	}
 
 	if (!translate && !review) && language != "" {


### PR DESCRIPTION
This pull request includes updates to the `internal/cli/cli.go` file to improve the user experience and error handling for the CLI tool. The most important changes involve setting default modes and refining error messages.

User experience improvements:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL94-R94): Marked the `single` mode as the default option in the flag description.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL123-R131): Added logic to default to `single` mode if neither `single` nor `multi` mode is specified.

Error handling improvements:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL123-R131): Updated the error message to clarify that both `multi` and `single` modes cannot be specified simultaneously.