### PR TITLE
fix CLI to remove prompt requirement in single/multi mode if unset

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -134,11 +134,6 @@ func (c *CLI) Run(args []string) int {
 		return ExitCodeFail
 	}
 
-	if (isMultiMode || isSingleMode) && prompt == "" {
-		fmt.Fprintf(c.errStream, "Error: The '-prompt' option is required in multi or single mode. Please specify '-prompt'.\n")
-		return ExitCodeFail
-	}
-
 	if c.isStdinTerminal && targetFile == "" {
 		fmt.Fprintf(c.errStream, "Error: The '-file' option is required when reading from standard input. Please specify '-file'.\n")
 		return ExitCodeFail


### PR DESCRIPTION
This pull request includes a small change to the `internal/cli/cli.go` file. The change removes the requirement for the `-prompt` option in multi or single mode.

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL137-L141): Removed the check and error message for the `-prompt` option in multi or single mode.