### PR TITLE
Update auto-review.yml to use pull request base ref for diffs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check for diffs and set SKIP_REVIEW
         run: |
-          diff_output=$(git diff origin/${{ github.event.repository.default_branch }}...HEAD)
+          diff_output=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD)
           diff_lines=$(echo "$diff_output" | wc -l)
           if [ -z "$diff_output" ]; then
             echo "No changes detected, skipping review."
@@ -37,7 +37,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          git diff origin/${{ github.event.repository.default_branch }}...HEAD | bento -review > review.txt
+          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | bento -review > review.txt
           REVIEW_CONTENT=$(cat review.txt)
           echo "REVIEW_CONTENT<<EOF" >> $GITHUB_ENV
           echo '### Automatic Review' >> $GITHUB_ENV


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/auto-review.yml` file to improve the accuracy of the diff comparisons in the automated review process.

Changes to diff comparisons:

* Updated the `diff_output` command to use the base reference of the pull request instead of the default branch of the repository. (`.github/workflows/auto-review.yml`, [.github/workflows/auto-review.ymlL23-R23](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dL23-R23))
* Modified the `bento -review` command to also use the base reference of the pull request for more accurate review content. (`.github/workflows/auto-review.yml`, [.github/workflows/auto-review.ymlL40-R40](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dL40-R40))