### PR TITLE
Update auto-review workflow to exclude 'go.sum' from diffs.

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: false
 
       - name: Download bento
         run: |
@@ -20,7 +21,7 @@ jobs:
 
       - name: Check for diffs and set SKIP_REVIEW
         run: |
-          diff_output=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          diff_output=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- ':!go.sum')
           diff_lines=$(echo "$diff_output" | wc -l)
           if [ -z "$diff_output" ]; then
             echo "No changes detected, skipping review."
@@ -37,7 +38,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | bento -review > review.txt
+          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- ':!go.sum' | bento -review > review.txt
           REVIEW_CONTENT=$(cat review.txt)
           echo "REVIEW_CONTENT<<EOF" >> $GITHUB_ENV
           echo '### Automatic Review' >> $GITHUB_ENV


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/auto-review.yml` file to improve the efficiency and accuracy of the auto-review workflow. The key changes involve modifying the git diff commands to exclude the `go.sum` file and adjusting the fetch settings for the checkout action.

Workflow improvements:

* [`.github/workflows/auto-review.yml`](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dR15): Added `fetch-tags: false` to the `actions/checkout` step to speed up the checkout process by not fetching tags.
* [`.github/workflows/auto-review.yml`](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dL23-R24): Updated the git diff command to exclude the `go.sum` file when checking for differences, ensuring that changes to this file do not trigger the review process. [[1]](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dL23-R24) [[2]](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dL40-R41)