### PR TITLE
Update README and CLI help text for the `-language` option clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Usage of bento:
   -help
         Print help information and quit
   -language string
-        Translate to language (default: en)
+        Specify the output language
   -limit int
         Limit the number of characters to translate (default 4000)
   -model string
@@ -105,11 +105,15 @@ git add -N .
 
 The `-review` option is used when you need to review the source code. This mode focuses on identifying issues in various aspects such as Completeness, Bugs, Security, Code Style, etc.
 
+You can also use the `-language` option to specify the output language of the review results.
+
 To review code, use the following command:
 
 ```sh
-git diff -w | bento -review -model gpt-4o
+git diff -w | bento -review -model gpt-4o -language Japanese
 ```
+
+In this example, the review results will be in Japanese. You can change the output language by specifying a different language with `-language`.
 
 For automation, you can use a GitHub Actions workflow. Below is an example workflow configuration file, [`.github/workflows/auto-review.yml`](/.github/workflows/auto-review.yml), which automatically runs a code review whenever there is a new pull request:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -93,7 +93,7 @@ func (c *CLI) Run(args []string) int {
 	flags.BoolVar(&isMultiMode, "multi", false, "Multi mode")
 	flags.BoolVar(&isSingleMode, "single", false, "Single mode (default)")
 
-	flags.StringVar(&language, "language", "", "Translate to language (default: en)")
+	flags.StringVar(&language, "language", "", "Specify the output language")
 	flags.StringVar(&prompt, "prompt", "", "Prompt text")
 	flags.StringVar(&systemPrompt, "system", "", "System prompt text")
 	flags.StringVar(&useModel, "model", "gpt-4o-mini", "Use models such as gpt-4o-mini, gpt-4-turbo, and gpt-4o")


### PR DESCRIPTION
This pull request includes updates to the documentation and code to clarify the usage of the `-language` option in the `bento` tool. The changes improve the clarity of the command-line options and provide examples for specifying the output language.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62): Updated the description of the `-language` option to "Specify the output language" and added examples demonstrating its usage in the `-review` command. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R117)

Code updates:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL96-R96): Modified the `-language` option description to "Specify the output language" to align with the updated documentation.