### PR TITLE
Add description flag for dump mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ The output will follow this format:
 3. The subsequent lines contain the file contents.
 4. The repository content ends with `--END--`.
 
+#### Description Flag
+
+The `-description` flag allows you to provide a specific description of the repository when using the dump mode. This description will be included in the output.
+
+```bash
+bento -dump -description "This is a sample repository description."
+```
+
 ### Using `-branch` and `-commit`
 
 - **`-branch`**: Use this when you haven't created a branch yet. It suggests a branch name based on the current Git diff.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Usage of bento:
         Suggest branch name
   -commit
         Suggest commit message
+  -description string
+        Description of the repository (dump mode)
   -dump
         Dump repository contents
   -file string

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -61,7 +61,6 @@ func (c *CLI) Run(args []string) int {
 		commitMessage    bool
 		translate        bool
 		review           bool
-		dump             bool
 
 		language     string
 		prompt       string
@@ -69,6 +68,9 @@ func (c *CLI) Run(args []string) int {
 		useModel     string
 		targetFile   string
 		repoPath     string
+
+		dump        bool
+		description string
 
 		isMultiMode  bool
 		isSingleMode bool
@@ -89,7 +91,9 @@ func (c *CLI) Run(args []string) int {
 	flags.BoolVar(&commitMessage, "commit", false, "Suggest commit message")
 	flags.BoolVar(&translate, "translate", false, "Translate text")
 	flags.BoolVar(&review, "review", false, "Review source code")
+
 	flags.BoolVar(&dump, "dump", false, "Dump repository contents")
+	flags.StringVar(&description, "description", "", "Description of the repository (dump mode)")
 
 	flags.IntVar(&limit, "limit", DefaultExceedThreshold, "Limit the number of characters to translate")
 
@@ -155,7 +159,7 @@ func (c *CLI) Run(args []string) int {
 			repoPath = flags.Arg(0)
 		}
 
-		if err := c.RunDump(repoPath); err != nil {
+		if err := c.RunDump(repoPath, description); err != nil {
 			fmt.Fprintf(c.errStream, "Error: %v\n", err)
 			return ExitCodeFail
 		}

--- a/internal/cli/dump_test.go
+++ b/internal/cli/dump_test.go
@@ -71,3 +71,20 @@ func TestRunDumpAIIgnore(t *testing.T) {
 		t.Errorf("files specified in .aiignore should not be included in the output")
 	}
 }
+
+func TestRunDump_WithDescription(t *testing.T) {
+	repoPath := "testdata/repo"
+	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
+	cli := NewCLI(outStream, errStream, inputStream, nil, false)
+
+	description := "This is a test description."
+	err := cli.RunDump(repoPath, description)
+	if err != nil {
+		t.Fatalf("RunDump failed: %v", err)
+	}
+
+	// Check that the output includes the description
+	if !strings.Contains(outStream.String(), description) {
+		t.Fatalf("Expected description %q to be in output, got: %q", description, outStream.String())
+	}
+}

--- a/internal/cli/dump_test.go
+++ b/internal/cli/dump_test.go
@@ -13,7 +13,7 @@ func TestRunDump(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cli := NewCLI(outStream, errStream, inputStream, nil, false)
 
-	err := cli.RunDump(repoPath)
+	err := cli.RunDump(repoPath, "")
 	if err != nil {
 		t.Fatalf("RunDump failed: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestRunDumpWithIgnorePatterns(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cli := NewCLI(outStream, errStream, inputStream, nil, false)
 
-	err := cli.RunDump(repoPath)
+	err := cli.RunDump(repoPath, "")
 	if err != nil {
 		t.Fatalf("RunDump failed: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestRunDumpIgnoresBinaryFiles(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cli := NewCLI(outStream, errStream, inputStream, nil, false)
 
-	err := cli.RunDump(repoPath)
+	err := cli.RunDump(repoPath, "")
 	if err != nil {
 		t.Fatalf("RunDump failed: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestRunDumpAIIgnore(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cli := NewCLI(outStream, errStream, inputStream, nil, false)
 
-	err := cli.RunDump(repoPath)
+	err := cli.RunDump(repoPath, "")
 	if err != nil {
 		t.Fatalf("RunDump failed: %v", err)
 	}


### PR DESCRIPTION
This pull request introduces a new `description` flag for the `dump` mode in the CLI tool, allowing users to add a description of the repository when dumping its contents. The changes include updates to the command-line interface, the `RunDump` function, and the associated tests.

Key changes include:

### CLI Enhancements:
* Added a new `description` flag to the CLI for the `dump` mode to allow users to provide a description of the repository. (`internal/cli/cli.go`, `README.md`) [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR72-R74) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR94-R96) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R58)

### Function Modifications:
* Updated the `RunDump` function to accept an additional `description` parameter and include it in the output if provided. (`internal/cli/dump.go`) [[1]](diffhunk://#diff-00031b90c16a4e5712a475e1ea68dfae01b846041657f2cdeadd8ac5e7867693L17-R17) [[2]](diffhunk://#diff-00031b90c16a4e5712a475e1ea68dfae01b846041657f2cdeadd8ac5e7867693L68-R83)

### Helper Functions:
* Introduced a new `unescapeString` function to process escape sequences in the description string. (`internal/cli/dump.go`)

### Test Updates:
* Modified tests for the `RunDump` function to accommodate the new `description` parameter. (`internal/cli/dump_test.go`) [[1]](diffhunk://#diff-93cdd7de957977dc1180f746604c28ae7ad1f50091ae87f565e97ee9adf77b0aL16-R16) [[2]](diffhunk://#diff-93cdd7de957977dc1180f746604c28ae7ad1f50091ae87f565e97ee9adf77b0aL35-R35) [[3]](diffhunk://#diff-93cdd7de957977dc1180f746604c28ae7ad1f50091ae87f565e97ee9adf77b0aL50-R50) [[4]](diffhunk://#diff-93cdd7de957977dc1180f746604c28ae7ad1f50091ae87f565e97ee9adf77b0aL65-R65)