### PR TITLE
replace context.Background() with t.Context()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/bento
 
-go 1.22.4
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -1,7 +1,6 @@
 package openai_test
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -68,7 +67,7 @@ func TestPostText_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := c.Chat(context.Background(), param)
+	res, err := c.Chat(t.Context(), param)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +124,7 @@ func TestPostText_Fail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.Chat(context.Background(), param)
+	_, err = c.Chat(t.Context(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")


### PR DESCRIPTION
This pull request includes updates to the Go module version and improvements to the test context handling in the `internal/openai` package.

### Go module version update:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.22.4` to `1.24.0`.

### Test context handling improvements:
* [`internal/openai/client_test.go`](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L4): Removed the unnecessary import of `context`.
* [`internal/openai/client_test.go`](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L71-R70): Updated the `TestPostText_Success` and `TestPostText_Fail` functions to use `t.Context()` instead of `context.Background()` for better test context handling. [[1]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L71-R70) [[2]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L128-R127)