### PR TITLE
add concurrency to auto-review workflow to cancel in-progress runs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -3,6 +3,10 @@ name: Auto Review
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for auto-review to include concurrency control, ensuring that only one instance of the workflow runs for a given pull request at a time.

Workflow improvements:

* [`.github/workflows/auto-review.yml`](diffhunk://#diff-71c3ea38d59fe17af5cdd94af63d4576e02b6d5f726e7b183a9821f4563bf03dR6-R9): Added a `concurrency` configuration to group workflows by the workflow name and reference, and to cancel any in-progress workflows for the same group.