### PR TITLE
Changed default value of model to gpt-5-nano

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,7 +23,7 @@ const (
 
 	DefaultExceedThreshold = 4000
 
-	DefaultOpenAIModel = "gpt-4.1-nano"
+	DefaultOpenAIModel = "gpt-5-nano"
 	DefaultGeminiModel = "gemini-2.0-flash-lite"
 )
 


### PR DESCRIPTION
This pull request makes a small update to the default OpenAI model used by the CLI. The default model has been changed from `gpt-4.1-nano` to `gpt-5-nano`.