### PR TITLE
Add "actions" language to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go"]
+        language: ["go", "actions"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
This pull request makes a minor update to the CodeQL workflow configuration, expanding the set of languages analyzed.

- The `language` matrix in `.github/workflows/codeql.yml` was updated to include both `"go"` and `"actions"` for CodeQL analysis.