### PR TITLE
add explicit permissions for contents in GitHub workflows

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -3,6 +3,10 @@ name: Auto Review
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write  # Required for creating releases and uploading assets
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration files to explicitly set the required permissions for each workflow. These changes help improve security by following the principle of least privilege and ensuring each workflow only has the access it needs.

Workflow permissions updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR12-R14): Added `permissions: contents: read` to restrict the workflow to read-only access to repository contents.
* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcR11-R13): Added `permissions: contents: read` to restrict the security workflow to read-only access.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R6-R9): Added `permissions: contents: write` to allow the release workflow to create releases and upload assets, with a clarifying comment.