### PR TITLE
Refactor OpenAI payloads to Input/Instructions

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -400,26 +400,23 @@ func (ot *openaiTranslator) request(ctx context.Context, systemPrompt, prompt, i
 	var data *openai.Payload
 	if systemPrompt != "" {
 		data = &openai.Payload{
-			Model: useModel,
-			Messages: []openai.Message{
-				{Role: "system", Content: systemPrompt},
-				{Role: "user", Content: prompt + input},
-			},
+			Model:        useModel,
+			Input:        prompt + input,
+			Instructions: systemPrompt,
 		}
 	} else {
 		data = &openai.Payload{
 			Model: useModel,
-			Messages: []openai.Message{
-				{Role: "user", Content: prompt + input},
-			},
+			Input: prompt + input,
 		}
 	}
 	resp, err := ot.client.Chat(ctx, data)
 	if err != nil {
 		return "", fmt.Errorf("http request: %w", err)
 	}
-	if len(resp.Choices) > 0 {
-		return resp.Choices[0].Message.Content, nil
+	outputText := resp.OutputText()
+	if outputText != "" {
+		return outputText, nil
 	}
-	return "", fmt.Errorf("no translation found")
+	return "", fmt.Errorf("no translation found: Response=%+v", resp)
 }

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -20,12 +20,7 @@ func TestPostText_Success(t *testing.T) {
 
 	param := &Payload{
 		Model: "gpt-3.5-turbo",
-		Messages: []Message{
-			{
-				Role:    "user",
-				Content: "Hello. I am a student.",
-			},
-		},
+		Input: "Hello. I am a student.",
 	}
 
 	token := "token"
@@ -73,18 +68,19 @@ func TestPostText_Success(t *testing.T) {
 	}
 
 	expected := &Response{
-		ID:      "chatcmpl-123",
-		Object:  "chat.completion",
-		Created: 1677652288,
-		Model:   "gpt-3.5-turbo-0613",
-		Choices: []Choice{
+		ID: "resp_67b73f697ba4819183a15cc17d011509",
+		Output: []OutputMessage{
 			{
-				Index: 0,
-				Message: Message{
-					Role:    "assistant",
-					Content: "\n\nHello there, how may I assist you today?",
+				ID:   "msg_67b73f697ba4819183a15cc17d011509",
+				Type: "message",
+				Role: "assistant",
+				Content: []Content{
+					{
+						Type:        "text",
+						Text:        "\n\nHello there, how may I assist you today?",
+						Annotations: []string{},
+					},
 				},
-				FinishReason: "stop",
 			},
 		},
 		Usage: Usage{
@@ -106,12 +102,7 @@ func TestPostText_Fail(t *testing.T) {
 
 	param := &Payload{
 		Model: "gpt-3",
-		Messages: []Message{
-			{
-				Role:    "user",
-				Content: "Hello. I am a student.",
-			},
-		},
+		Input: "Hello. I am a student.",
 	}
 
 	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/openai/testdata/chat_ok.json
+++ b/internal/openai/testdata/chat_ok.json
@@ -1,16 +1,17 @@
 {
-  "id": "chatcmpl-123",
-  "object": "chat.completion",
-  "created": 1677652288,
-  "model": "gpt-3.5-turbo-0613",
-  "choices": [
+  "id": "resp_67b73f697ba4819183a15cc17d011509",
+  "output": [
     {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "\n\nHello there, how may I assist you today?"
-      },
-      "finish_reason": "stop"
+      "id": "msg_67b73f697ba4819183a15cc17d011509",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "\n\nHello there, how may I assist you today?",
+          "annotations": []
+        }
+      ]
     }
   ],
   "usage": {


### PR DESCRIPTION
This pull request updates the OpenAI API integration to support a new API format and response structure. The main changes include updating the payload and response types, changing how prompts are sent, and updating the test cases and test data to match the new API. These changes ensure compatibility with the new OpenAI endpoint and response schema.

**API Payload and Response Structure Updates:**

* Changed `Payload` to use `Input` and `Instructions` fields instead of the previous `Messages` array, aligning with the new API requirements (`internal/openai/client.go`).
* Updated `Response` to use an `Output` array of `OutputMessage` objects, replacing the old `Choices` array, and added new types for `OutputMessage` and `Content` (`internal/openai/client.go`).
* Added the `OutputText()` helper method to extract the first text content from the new response structure (`internal/openai/client.go`).

**Endpoint and Request Handling:**

* Changed the API endpoint from `/v1/chat/completions` to `/v1/responses` (`internal/openai/client.go`).
* Updated the request logic to use the new payload structure and response parsing, including improved error messages and output extraction (`internal/cli/cli.go`, `internal/openai/client.go`) [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL404-R421) [[2]](diffhunk://#diff-4f6794af8c4757c8405002d47100706709f07870b80df0c809f039ca5bdacdbbL92-R111).

**Test and Test Data Updates:**

* Modified tests and test data to match the new payload and response formats, ensuring continued test coverage and correctness (`internal/openai/client_test.go`, `internal/openai/testdata/chat_ok.json`) [[1]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L23-R23) [[2]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L76-L87) [[3]](diffhunk://#diff-f990aa0358be9e09c2dcd43baa735daeac4ab1be0cb05208ae6382e4e7191764L109-R105) [[4]](diffhunk://#diff-b6393db070073c64967d73f6f591581885055286e3a90031655482e735cf7323L2-R14).