### PR TITLE
Rename OSV scanner workflow and extract scheduled scan to separate file

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,20 @@
+name: OSV-Scanner PR Scan
+
+# Change "main" to your default branch if you use a different name, i.e. "master"
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.1"

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,13 +1,11 @@
-name: OSV-Scanner PR Scan
+name: OSV-Scanner Scheduled Scan
 
-# Change "main" to your default branch if you use a different name, i.e. "master"
 on:
-  pull_request:
-    branches: [main]
-  merge_group:
-    branches: [main]
   schedule:
     - cron: "30 12 * * 1"
+  # Change "main" to your default branch if you use a different name, i.e. "master"
+  push:
+    branches: [main]
 
 permissions:
   # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
@@ -20,5 +18,3 @@ permissions:
 jobs:
   scan-scheduled:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1"
-  scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.1"


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows for OSV-Scanner by separating the scheduled scan into its own workflow file and simplifying the pull request scan workflow. The main goal is to improve maintainability and clarity of the CI configuration.

**Workflow Refactoring:**

* Created a new workflow file, `.github/workflows/osv-scanner-scheduled.yml`, dedicated to running the OSV-Scanner on a schedule (weekly via cron) and on pushes to `main`. This file now handles the scheduled scan job.
* Removed the scheduled scan job and its associated cron trigger from the pull request workflow (now `.github/workflows/osv-scanner-pr.yml`), so that it only runs for pull requests. [[1]](diffhunk://#diff-f882c90d0c26ba9a83f911b7c90355d58d3dc1f40a49e38d20878e956cbffc96L9-L10) [[2]](diffhunk://#diff-f882c90d0c26ba9a83f911b7c90355d58d3dc1f40a49e38d20878e956cbffc96L21-L22)