### PR TITLE
Add GoVersionOverride to osv-scanner.toml and update renovate config

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,1 @@
+GoVersionOverride = "1.25.5"

--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,16 @@
       "matchStrings": [
         "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "fileMatch": [
+        "osv-scanner.toml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "GoVersionOverride = \"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\""
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request adds support for tracking and updating the Go version specified in the `osv-scanner.toml` file. It does this by both introducing a new configuration entry in `osv-scanner.toml` and updating the Renovate configuration to recognize and manage this version setting.

Configuration changes:

* Added a `GoVersionOverride` field to `osv-scanner.toml` to explicitly specify the Go version used.

Renovate integration:

* Updated `renovate.json` to include a new rule that detects and manages the Go version in `osv-scanner.toml` using the `golang-version` datasource and a custom match string.