### PR TITLE
separate golang and golang-security

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
         ".github/workflows/security.yml"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "golang-security",
       "matchStrings": [
         "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
@@ -38,10 +38,23 @@
         "osv-scanner.toml"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "golang-security",
       "matchStrings": [
         "GoVersionOverride = \"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\""
       ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "golang"
+      ]
+    },
+    {
+      "matchDepNames": [
+        "golang-security"
+      ],
+      "groupName": "go-version-security"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve the handling of Go version dependencies, particularly for security-related workflows. The main changes involve renaming dependency templates and introducing package rules to better organize and group Go version updates.

Dependency template adjustments:

* Changed the `depNameTemplate` from `"golang"` to `"golang-security"` for security-related Go version updates in both workflow and configuration files. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L21-R21) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L41-R59)

Package rules improvements:

* Added new `packageRules` to group and manage dependencies: one for matching `"golang"` and another for grouping `"golang-security"` updates under the group name `"go-version-security"`.