### PR TITLE
fix: update golang depNameTemplate to go and allow quoted versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,9 @@
         "/.github/workflows/go.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go",
       "matchStrings": [
-        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -20,9 +20,9 @@
         "/.github/workflows/security.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang-security",
+      "depNameTemplate": "go-security",
       "matchStrings": [
-        "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version-input: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -31,9 +31,9 @@
         "/.github/workflows/release.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go",
       "matchStrings": [
-        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -42,21 +42,21 @@
         "/osv-scanner.toml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang-security",
+      "depNameTemplate": "go-security",
       "matchStrings": [
-        "GoVersionOverride = \"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\""
+        "GoVersionOverride = \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     }
   ],
   "packageRules": [
     {
       "matchDepNames": [
-        "golang"
+        "go"
       ]
     },
     {
       "matchDepNames": [
-        "golang-security"
+        "go-security"
       ],
       "groupName": "go-version-security"
     }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to align Go dependency naming conventions with upstream standards and to improve version string matching. The changes primarily rename dependency templates and update regular expressions to support both quoted and unquoted Go version strings.

Dependency naming updates:

* Changed `depNameTemplate` and `matchDepNames` values from `golang` to `go` and from `golang-security` to `go-security` throughout the configuration for consistency with upstream naming. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L12-R14) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L23-R25) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L34-R36) [[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L45-R59)

Regular expression improvements:

* Updated `matchStrings` regular expressions to allow Go version numbers to be optionally enclosed in quotes, ensuring compatibility with different formatting styles in workflow and configuration files. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L12-R14) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L23-R25) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L34-R36) [[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L45-R59)