### PR TITLE
update default model from gpt-4o-mini to gpt-5-nano in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make
 - **Repository Dump**: The `-dump` command extracts repository content while respecting `.gitignore` and `.aiignore`.
 - **Customization**: Use `-multi` or `-single` and override prompts with `-prompt`.
 - **Default Model**:
-  - For OpenAI: default is `gpt-4o-mini`.
+  - For OpenAI: default is `gpt-5-nano` for the lowest cost among the current GPT-5 models.
   - For Gemini (with `-backend gemini`): default is `gemini-2.0-flash-lite`.
 - **Translation**: The `-translate` command translates to English by default; change target language with `-language`.
 - **Code Review**: Use `-review` to get code feedback. Specify the output language with `-language`.
@@ -74,7 +74,7 @@ Usage of bento:
   -limit int
         Limit the number of characters to translate (default 4000)
   -model string
-        Use models such as gpt-4o-mini, gpt-4-turbo, and gpt-4o. (When using the gemini backend, the default model becomes gemini-2.0-flash-lite) (default "gpt-4o-mini")
+        Use models such as gpt-5-nano, gpt-5-mini, and gpt-5. (When using the gemini backend, the default model becomes gemini-2.0-flash-lite) (default "gpt-5-nano")
   -multi
         Multi mode
   -prompt string
@@ -146,7 +146,7 @@ You can also use the `-language` option to specify the output language of the re
 To review code, use the following command:
 
 ```sh
-git diff -w | bento -review -model gpt-4o -language Japanese
+git diff -w | bento -review -model gpt-5 -language Japanese
 ```
 
 In this example, the review results will be in Japanese. You can change the output language by specifying a different language with `-language`.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -119,7 +119,7 @@ func (c *CLI) Run(args []string) int {
 	flags.StringVar(&language, "language", "", "Specify the output language")
 	flags.StringVar(&prompt, "prompt", "", "Prompt text")
 	flags.StringVar(&systemPrompt, "system", "", "System prompt text")
-	flags.StringVar(&useModel, "model", DefaultOpenAIModel, "Use models such as gpt-4o-mini, gpt-4-turbo, and gpt-4o. (When using the gemini backend, the default model becomes "+DefaultGeminiModel+")")
+	flags.StringVar(&useModel, "model", DefaultOpenAIModel, "Use models such as gpt-5-nano, gpt-5-mini, and gpt-5. (When using the gemini backend, the default model becomes "+DefaultGeminiModel+")")
 	flags.StringVar(&backend, "backend", "openai", "Backend to use: openai or gemini")
 
 	err := flags.Parse(args[1:])


### PR DESCRIPTION
This pull request updates the default OpenAI model used in the CLI tool and its documentation from the GPT-4 family to the newer GPT-5 family, ensuring users benefit from the latest available models at the lowest cost. The changes also update examples and help text to reflect the new default models.

**Documentation and CLI updates:**

* Updated the documented default OpenAI model from `gpt-4o-mini` to `gpt-5-nano` in the `README.md`, providing users with more current information and highlighting the cost benefits of the new model.
* Updated the `-model` flag usage description in both the `README.md` and CLI help text to reference GPT-5 models (`gpt-5-nano`, `gpt-5-mini`, `gpt-5`) instead of GPT-4 models. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R77) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL122-R122)
* Changed the example code review command in the `README.md` to use `gpt-5` instead of `gpt-4o`, aligning examples with the new default model.